### PR TITLE
Support `origin_url` field on entries

### DIFF
--- a/wallabag.Api/Models/WallabagItem.cs
+++ b/wallabag.Api/Models/WallabagItem.cs
@@ -107,6 +107,12 @@ namespace wallabag.Api.Models
         [JsonProperty("preview_picture")]
         public Uri PreviewImageUri { get; set; }
 
+        /// <summary>
+        /// Gets or sets the original article URL.
+        /// </summary>
+        [JsonProperty("origin_url")]
+        public string OriginalUrl { get; set; }
+
 
         public override string ToString() => Title ?? string.Empty;
         public override bool Equals(object obj)


### PR DESCRIPTION
This field was added in Wallabag version 2.3.4; here's the relevant PR: https://github.com/wallabag/wallabag/pull/3553

Closes https://github.com/jlnostr/wallabag-api/issues/7